### PR TITLE
Add rails boot benchmarks

### DIFF
--- a/rails/benchmarks/bm_rails_boot_env.rb
+++ b/rails/benchmarks/bm_rails_boot_env.rb
@@ -1,0 +1,14 @@
+require_relative 'support/benchmark_rails'
+
+begin
+  system("rails new my_app > /dev/null")
+
+  Dir.chdir("my_app") do
+    Benchmark.rails("rails_boot_env", time: 10) do
+      system("DISABLE_SPRING=1 bin/rake environment > /dev/null")
+    end
+  end
+ensure
+  system("rm -rf my_app")
+end
+

--- a/rails/benchmarks/bm_rails_boot_test.rb
+++ b/rails/benchmarks/bm_rails_boot_test.rb
@@ -1,0 +1,16 @@
+# only run this benchmark with rails >= 5
+
+require_relative 'support/benchmark_rails'
+
+begin
+  system("rails new my_app > /dev/null")
+
+  Dir.chdir("my_app") do
+    Benchmark.rails("rails_boot_test", time: 10) do
+      system("DISABLE_SPRING=1 bin/rake test > /dev/null")
+    end
+  end
+ensure
+  system("rm -rf my_app")
+end
+


### PR DESCRIPTION
Pretty much the same as https://github.com/Shopify/ruby-bench-suite/pull/1 but pulled into `bm_*` files